### PR TITLE
added public init to PSCard class

### DIFF
--- a/Pod/Classes/Models/PSCard.h
+++ b/Pod/Classes/Models/PSCard.h
@@ -29,7 +29,13 @@ typedef enum : NSUInteger {
 - (BOOL)isValidCardNumber;
 - (BOOL)isValidCard;
 
+- (instancetype)initWithPan: (NSString *)pan
+                expereMonth: (int)mm
+                 expireYear: (int)yy
+                        cvv: (NSString *)cvv;
+
 + (NSString *)getCardTypeName:(PSCardType)type;
 + (PSCardType)getCardType:(NSString *)typeName;
+
 
 @end

--- a/Pod/Classes/Models/PSCard.m
+++ b/Pod/Classes/Models/PSCard.m
@@ -45,6 +45,21 @@ PSCardType cardTypeWithString(NSString *str) {
 
 @implementation PSCard
 
+- (instancetype)initWithPan: (NSString *)pan
+                expereMonth: (int)mm
+                 expireYear: (int)yy
+                        cvv: (NSString *)cvv {
+    self = [super init];
+    
+    if (self) {
+        self.cardNumber = pan;
+        self.mm = mm;
+        self.yy = yy;
+        self.cvv = cvv;
+    }
+    return self;
+}
+
 + (instancetype)cardWith:(NSString *)cardNumber
                 expireMm:(int)mm
                 expireYy:(int)yy


### PR DESCRIPTION
I tried to perform pay request without PSCardInputLayout and noticed PSCard object doesn't have public initialisers, so I wasn't able to create PSCard object. So, this pull request is attempt to fix it.